### PR TITLE
Type updates

### DIFF
--- a/ctrlnet.go
+++ b/ctrlnet.go
@@ -9,16 +9,16 @@ import (
 
 type LinkSettings struct {
 	// Latency between links (in milliseconds)
-	Latency    int
-	
+	Latency uint
+
 	// Jitter in latency values (in milliseconds)
-	Jitter     int
-	
+	Jitter uint
+
 	// Bandwidth of link (in bits per second)
-	Bandwidth  int
-	
+	Bandwidth uint
+
 	// PacketLoss percentage on the links (in whole percentage points)
-	PacketLoss int
+	PacketLoss uint8
 }
 
 func (ls *LinkSettings) cmd(iface string, init bool) []string {
@@ -31,15 +31,15 @@ func (ls *LinkSettings) cmd(iface string, init bool) []string {
 
 	// even if latency is zero, put it on so the command never fails
 	base = append(base, "delay", fmt.Sprintf("%dms", ls.Latency))
-	if ls.Jitter > 0 {
+	if ls.Jitter != 0 {
 		base = append(base, fmt.Sprintf("%dms", ls.Jitter), "distribution", "normal")
 	}
 
-	if ls.Bandwidth > 0 {
+	if ls.Bandwidth != 0 {
 		base = append(base, "rate", fmt.Sprint(ls.Bandwidth))
 	}
 
-	if ls.PacketLoss > 0 {
+	if ls.PacketLoss != 0 {
 		base = append(base, "loss", fmt.Sprintf("%d%%", ls.PacketLoss))
 	}
 


### PR DESCRIPTION
-   Update the LinkSettings values to be `uint` rather than `int`.
    -   Exception: `PacketLoss` is a `uint8` since max is 100.
-   Make corresponding updates to value checks.
    -   In particular, check `!= 0` rather than `> 0`.